### PR TITLE
Added a null check for shipping methods

### DIFF
--- a/src/Model/Api/Ecster.php
+++ b/src/Model/Api/Ecster.php
@@ -672,6 +672,11 @@ class Ecster
         $_rates = $address->getAllShippingRates();
         /** @var \Magento\Quote\Model\Quote\Address\Rate $_rate */
         foreach ($_rates as $_rate) {
+            // There are cases where third party modules restrict the shipping method but doesn't remove it.
+            // In those cases we don't want to send them to Ecster because it will throw an exception
+            if ($_rate->getMethod() === null) {
+                continue;
+            }
             $methodPrice = $this->taxHelper->getShippingPrice($_rate->getPrice(), true, $address);
             $shippingMethods[] = [
                 "id" => $_rate->getMethod(),


### PR DESCRIPTION
Added a null check for shipping methods to better work with third party modules.

I.e. Amasty Shipping Restriction doesn't remove the method if you choose to have a message on the methods which causes exceptions in Ecster API calls.